### PR TITLE
Add standards-runtime image variant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 ARG PHP_VERSION
-FROM php:${PHP_VERSION}
+FROM php:${PHP_VERSION} as standards-runtime
 
-ENV PYTHONUNBUFFERED=1
 RUN apt-get update
-RUN apt-get install -y unzip libpng-dev libicu-dev libxslt-dev jq git libzip-dev wget python3-dev python3-pip
+RUN apt-get install -y unzip libpng-dev libicu-dev libxslt-dev jq git libzip-dev wget
+RUN apt-get clean
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
@@ -12,6 +12,12 @@ RUN docker-php-ext-install gd bcmath zip intl xsl pdo_mysql soap sockets
 RUN mkdir /composer
 COPY composer.json /composer
 RUN cd /composer && composer install
+
+FROM standards-runtime
+
+ENV PYTHONUNBUFFERED=1
+RUN apt-get install -y python3-dev python3-pip
+RUN apt-get clean
 
 COPY pipe /
 RUN chmod a+x /pipe.py

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Add the following your `bitbucket-pipelines.yml` file:
 | MAGENTO_PASS          | (Optional) Injects repo.magento.com password into auth.json|
 | EXCLUDE_EXPRESSION    | (Optional) A grep [regular expression](https://www.gnu.org/software/grep/manual/html_node/Basic-vs-Extended.html) to exclude files from standards testing|
 
+## Local use
+An intermediate build target `standards-runtime` is available which does not include the Bitbucket specific pip aspects. This essentially just provides a runtime for PHPCS which can be used by CLI tools and IDE integrations.
+
+
 ## Development
 
 The following command can be used to invoke the pipe locally:

--- a/hooks/build
+++ b/hooks/build
@@ -1,2 +1,6 @@
 #!/bin/bash
-docker build --build-arg PHP_VERSION="$(echo $DOCKER_TAG | sed 's/-experimental//g')" -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+if [[ "$DOCKER_TAG" == *"runtime"* ]]; then
+     docker build --target standards-runtime --build-arg PHP_VERSION="$(echo $DOCKER_TAG | sed 's/-experimental//g' | sed 's/-runtime//g')" -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+else
+     docker build --build-arg PHP_VERSION="$(echo $DOCKER_TAG | sed 's/-experimental//g')" -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+fi


### PR DESCRIPTION
This PR adds a build target which only provides a runtime for the code standards / PHPCS without all of the associated Bitbucket pipe logic. This can be used by IDE integrations to get access to the standards rules.