### PR TITLE
Github actions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,32 @@ Add the following your `bitbucket-pipelines.yml` file:
                 MAGENTO_USER: "USER"
                 MAGENTO_PASS: "PASS"
 ```
+
+### Github Actions
+This pipe has partial support for Github actions. Please ensure that `SKIP_DEPENDENCIES` = `true`.
+
+```yaml
+  code-standards:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Code Standards Test
+        uses: docker://aligent/code-standards-pipe-php:7.4-experimental
+        env:
+          STANDARDS: "Magento2"
+          SKIP_DEPENDENCIES: "true"
+```
+
 ## Variables
 
 | Variable              | Usage                                                       |
 | --------------------- | ----------------------------------------------------------- |
 | STANDARDS             | The PHPCS standards to run (Security checks will always be run) |
 | DEBUG                 | (Optional) Turn on extra debug information. Default: `false`. |
-| SKIP_DEPENDENCIES     | (Optional) Skip installing project composer dependencies. Default: `false`. |
+| SKIP_DEPENDENCIES     | (Optional) Skip installing project composer dependencies. Default: `false`. For Github actions this should be set to `true`. |
 | MAGENTO_USER          | (Optional) Injects repo.magento.com user into auth.json |
 | MAGENTO_PASS          | (Optional) Injects repo.magento.com password into auth.json|
 | EXCLUDE_EXPRESSION    | (Optional) A grep [regular expression](https://www.gnu.org/software/grep/manual/html_node/Basic-vs-Extended.html) to exclude files from standards testing|

--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -121,6 +121,9 @@ class PHPCodeStandards(Pipe):
 
             changed_files = list(filter(filter_paths, changed_files))
 
+        else:
+            self.log_info(f"Exclude expression not provided. All changed files will be scanned.")
+
         if not changed_files:
             self.success("No changed files to scan")
             self.standards_failure = False

--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -39,6 +39,7 @@ class PHPCodeStandards(Pipe):
         self.bitbucket_pipeline_uuid = os.getenv('BITBUCKET_PIPELINE_UUID')
         self.bitbucket_step_uuid = os.getenv('BITBUCKET_STEP_UUID')
         self.bitbucket_commit = os.getenv('BITBUCKET_COMMIT')
+        self.github_actions = os.getenv('GITHUB_ACTIONS')
 
     def setup_ssh_credentials(self):
         ssh_dir = os.path.expanduser("~/.ssh/")
@@ -236,11 +237,15 @@ class PHPCodeStandards(Pipe):
     def run(self):
         super().run()
         if not self.skip_dependencies:
+            if self.github_actions:
+                self.fail(message=f"Dependency installation not suppoted on Github.\nPlease use SKIP_DEPENDENCIES=true.")
             self.setup_ssh_credentials()
             self.inject_composer_credentials()
             self.composer_install()
         self.run_code_standards_check()
-        self.upload_report()
+
+        if not self.github_actions:
+            self.upload_report()
 
         if self.standards_failure:
             self.fail(message=f"Failed code standards test")

--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -115,7 +115,9 @@ class PHPCodeStandards(Pipe):
                 match = re.search(self.exclude_expression, path)
                 if match:
                     self.log_info(f"Excluding: {path}")
-                return False if match else True
+                else:
+                    self.log_info(f"Testing: {path}")
+                return not match
 
             changed_files = list(filter(filter_paths, changed_files))
 


### PR DESCRIPTION
Adds partial support for Github actions.
Support in this instance means dissabling Bitbucket specific features such as Codeinsights reports.

Please see readme instructions for usage.

`DO-1280`