### PR TITLE
Add phpcompatibility/php-compatibility to fix Magento Coding Standard…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
   "require": {
        "magento/magento-coding-standard": "^23",
        "pheromone/phpcs-security-audit": "^2.0",
-       "squizlabs/php_codesniffer": "^3.5"
+       "squizlabs/php_codesniffer": "^3.5",
+       "phpcompatibility/php-compatibility": "^9.3"
   },
   "license": [
     "GPL-3"


### PR DESCRIPTION
To fix the below error:

`ERROR: Referenced sniff "PHPCompatibility.FunctionUse.RemovedFunctions" does not exist`