### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-*@aligent/dev-ops
+composer.json @aligent-lturner
+
+* @aligent/aligent-devops 


### PR DESCRIPTION
Updates codeowners so changes to `composer.json` don't require DO approval. 