### PR TITLE
fix: removed version 7.4 from build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [7.4, 8.0, 8.1, 8.2]
+        version: [8.0, 8.1, 8.2]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the following your `bitbucket-pipelines.yml` file:
       - step:
           name: "Code Standards check"
           script:
-            - pipe: docker://aligent/code-standards-pipe-php:7.4
+            - pipe: docker://aligent/code-standards-pipe-php:8.2
               variables:
                 STANDARDS: "Magento2"
                 SKIP_DEPENDENCIES: "true"


### PR DESCRIPTION
Removed version 7.4 from build list as per [comment](https://github.com/aligent/code-standards-pipe-php/pull/37#issuecomment-2174678569)
not sure if it should be removed in `README.md` too