### PR TITLE
Update to v33 and replace php-compatability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,24 @@
 {
-    "name": "aligent/code-standards",
-    "version": "1.0.0",
-    "description": "Composer requirements for Alignet code standards checks",
-    "type": "magento2-module",
-    "require": {
-        "magento/magento-coding-standard": "^31",
-        "pheromone/phpcs-security-audit": "^2.0",
-        "squizlabs/php_codesniffer": "^3.5",
-        "phpcompatibility/php-compatibility": "^9.3"
-    },
-    "license": [
-        "GPL-3"
+  "name": "aligent/code-standards",
+  "version": "1.0.0",
+  "description": "Composer requirements for Alignet code standards checks",
+  "type": "magento2-module",
+  "require": {
+    "magento/magento-coding-standard": "^33",
+    "pheromone/phpcs-security-audit": "^2.0",
+    "squizlabs/php_codesniffer": "^3.5",
+    "magento/php-compatibility-fork": "0.1.0"
+  },
+  "license": [
+    "GPL-3"
+  ],
+  "scripts": {
+    "post-install-cmd": [
+      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/,../../pheromone/phpcs-security-audit/,../../magento/php-compatibility-fork)"
     ],
-    "scripts": {
-        "post-install-cmd": [
-            "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/,../../pheromone/phpcs-security-audit/,../../phpcompatibility/php-compatibility)"
-        ],
-        "post-update-cmd": [
-            "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/,../../pheromone/phpcs-security-audit/,../../phpcompatibility/php-compatibility)"
-        ],
-        "check-style": "./vendor/bin/phpcs --standard=Magento2 --colors --report=summary app"
-    }
+    "post-update-cmd": [
+      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/,../../pheromone/phpcs-security-audit/,../../magento/php-compatibility-fork)"
+    ],
+    "check-style": "./vendor/bin/phpcs --standard=Magento2 --colors --report=summary app"
+  }
 }


### PR DESCRIPTION
Updated `magento/magento-coding-standard` to v33 
Swapped to `php-compatability-fork` from `phpcompatibility/php-compatibility` and changed scripts to use this fork

