### PR TITLE
bump up runtime memory limit to 512M, and allow phpcs plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ RUN docker-php-ext-install gd bcmath zip intl xsl pdo_mysql soap sockets
 
 RUN mkdir /composer
 COPY composer.json /composer
-RUN cd /composer && composer install
+RUN cd /composer && \
+    composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true && \
+    composer install
 
 FROM standards-runtime
 

--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -134,6 +134,8 @@ class PHPCodeStandards(Pipe):
             os.mkdir("test-results")
 
         phpcs_command = ["/composer/vendor/bin/phpcs",
+                         "-d",
+                         "memory_limit=512M",
                          "--report=junit",
                          f"--standard={self.standards}"
                          ] + changed_files


### PR DESCRIPTION
Address the below errors
- "memory exhausted" in phpcs.xml
```
$ cat phpcs.xml                                                  
                                                                                                                         
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 4194312 bytes) in /composer/vendor/squizlabs/php_codesniffer/src/Fixer.php on line 129
                                                                                                                         
The PHP_CodeSniffer "phpcs" command ran out of memory.                                                                                                                                                                                             
Either raise the "memory_limit" of PHP in the php.ini file or raise the memory limit at runtime                          
using `phpcs -d memory_limit=512M` (replace 512M with the desired memory limit).
```


- allow-plugins error during docker image build

```
9.870   - Installing squizlabs/php_codesniffer (3.10.3): Extracting archive                                                                                                                                                                        
10.74                                                                                                                                                                                                                                              
10.74 In PluginManager.php line 782:                                                                                                                                                                                                               
10.74                                                                                                                                                                                                                                              
10.74   dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin w                                                                                                                                                                
10.74   hich is blocked by your allow-plugins config. You may add it to the list if                                                                                                                                                                
10.74    you consider it safe.                                                                                                                                                                                                                     
10.74   You can run "composer config --no-plugins allow-plugins.dealerdirect/phpcod                                                                                                                                                                
10.74   esniffer-composer-installer [true|false]" to enable it (true) or disable it                                                                                                                                                                
10.74    explicitly and suppress this exception (false)                                                                                                                                                                                            
10.74   See https://getcomposer.org/allow-plugins 
```