### PR TITLE
AKD-831: parameterise ALPINE_VERSION for the upstream, failing the bu…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [8.0, 8.1, 8.2]
+        php-version: [8.0, 8.1, 8.2, 8.3, 8.4]
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.release.target_commitish }}
-      - run: docker build . --build-arg PHP_VERSION=${{ matrix.version }}
+      - run: docker build . --build-arg PHP_VERSION=${{ matrix.php-version }} --build-arg ALPINE_VERSION=${{ vars.ALPINE_VERSION }} -t my-app:${{ matrix.php-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.0, 8.1, 8.2, 8.3, 8.4]
+        php-version: [8.3, 8.4]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 ARG PHP_VERSION
-FROM php:${PHP_VERSION}-alpine3.21 as standards-runtime
+ARG ALPINE_VERSION
+ARG ALPINE_VERSION_REQUIRED=${ALPINE_VERSION:?ALPINE_VERSION build argument is required}
+FROM php:${PHP_VERSION}-alpine${ALPINE_VERSION} as standards-runtime
 
 # Install system dependencies
 RUN apk update && apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 ARG PHP_VERSION
 ARG ALPINE_VERSION
-ARG ALPINE_VERSION_REQUIRED=${ALPINE_VERSION:?ALPINE_VERSION build argument is required}
-FROM php:${PHP_VERSION}-alpine${ALPINE_VERSION} as standards-runtime
+
+FROM busybox:latest AS validator
+ARG ALPINE_VERSION
+RUN : "${ALPINE_VERSION:?ALPINE_VERSION build argument is required}" && touch /validated
+
+FROM php:${PHP_VERSION}-alpine${ALPINE_VERSION} AS standards-runtime
+COPY --from=validator /validated /tmp/.validated
 
 # Install system dependencies
 RUN apk update && apk add --no-cache \


### PR DESCRIPTION
…st (empty) as default

**Description of the proposed changes**

specify apline version through env var instead of hardcoded value. 


**Screenshots (if applicable)**

**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/.github/blob/main/CONTRIBUTING.md).

**Notes to reviewers**
php official docker repo offers `{PHP_VERSION}-alpine` (the latest alpine), along with `{PHP_VERSION}-alpine{ALPINE_VERSION}`.Docker image build will fail if ALPINE_VERSION is not present, to avoid using the latest with regard to supply chain attack.

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

**Time Tracking**

ABC-xxx: code review, select project XXXX